### PR TITLE
Fix two NPEs

### DIFF
--- a/src/main/java/de/katzenpapst/amunra/block/BlockSlabMeta.java
+++ b/src/main/java/de/katzenpapst/amunra/block/BlockSlabMeta.java
@@ -236,8 +236,9 @@ public class BlockSlabMeta extends BlockSlab implements IMetaBlock, IMassiveBloc
      * @return
      */
     @Override
-    public String getHarvestTool(final int metadata) {
-        return this.getSubBlock(metadata).getHarvestTool(metadata);
+    public String getHarvestTool(int metadata) {
+        final SubBlock sb = this.getSubBlock(metadata);
+        return sb == null ? null : sb.getHarvestTool(metadata);
     }
 
     /**
@@ -248,8 +249,9 @@ public class BlockSlabMeta extends BlockSlab implements IMetaBlock, IMassiveBloc
      * @return Harvest level, or -1 if not the specified tool type.
      */
     @Override
-    public int getHarvestLevel(final int metadata) {
-        return this.getSubBlock(metadata).getHarvestLevel(metadata);
+    public int getHarvestLevel(int metadata) {
+        final SubBlock sb = this.getSubBlock(metadata);
+        return sb == null ? -1 : sb.getHarvestLevel(metadata);
     }
 
     /**

--- a/src/main/java/de/katzenpapst/amunra/mothership/MothershipWorldProvider.java
+++ b/src/main/java/de/katzenpapst/amunra/mothership/MothershipWorldProvider.java
@@ -267,7 +267,7 @@ public class MothershipWorldProvider extends WorldProviderSpace implements IZero
 
     @Override
     public String getDimensionName() {
-        return this.mothershipObj.getLocalizedName();
+        return this.mothershipObj == null ? "Mothership" : this.mothershipObj.getLocalizedName();
     }
 
     @Override


### PR DESCRIPTION
Fixes
```
[18:03:38] [Client thread/ERROR] [TConstruct/IguanaTweaksTConstruct]: **********************************************************************
[18:03:38] [Client thread/ERROR] [TConstruct/IguanaTweaksTConstruct]: * An Error occurred while creating default files for the Block Override
[18:03:38] [Client thread/ERROR] [TConstruct/IguanaTweaksTConstruct]: *  at iguanaman.iguanatweakstconstruct.override.IguanaOverride.doOverride(IguanaOverride.java:46)
[18:03:38] [Client thread/ERROR] [TConstruct/IguanaTweaksTConstruct]: *  at iguanaman.iguanatweakstconstruct.override.IguanaOverride.postInit(IguanaOverride.java:30)
[18:03:38] [Client thread/ERROR] [TConstruct/IguanaTweaksTConstruct]: *  at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
[18:03:38] [Client thread/ERROR] [TConstruct/IguanaTweaksTConstruct]: *  at java.base/java.lang.reflect.Method.invoke(Method.java:578)
[18:03:38] [Client thread/ERROR] [TConstruct/IguanaTweaksTConstruct]: *  at mantle.pulsar.control.PulseManager.findAndInvokeHandlers(PulseManager.java:237)
[18:03:38] [Client thread/ERROR] [TConstruct/IguanaTweaksTConstruct]: *  at mantle.pulsar.control.PulseManager.postInit(PulseManager.java:216)...
[18:03:38] [Client thread/ERROR] [TConstruct/IguanaTweaksTConstruct]: **********************************************************************
[18:03:38] [Client thread/ERROR] [IguanaTweaksTConstruct/IguanaTweaksTConstruct]: java.lang.NullPointerException: Cannot invoke "de.katzenpapst.amunra.block.SubBlock.getHarvestLevel(int)" because the return value of "de.katzenpapst.amunra.block.BlockSlabMeta.getSubBlock(int)" is null
```
and
```
[18:07:08] [CraftPresence-Dimension-Lookup/INFO] [STDERR/craftpresence]: [java.lang.Throwable$WrappedPrintStream:println:785]: java.lang.NullPointerException: Cannot invoke "de.katzenpapst.amunra.mothership.Mothership.getLocalizedName()" because "this.mothershipObj" is null
[18:07:08] [CraftPresence-Dimension-Lookup/INFO] [STDERR/craftpresence]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at de.katzenpapst.amunra.mothership.MothershipWorldProvider.func_80007_l(MothershipWorldProvider.java:270)
[18:07:08] [CraftPresence-Dimension-Lookup/INFO] [STDERR/craftpresence]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at forge.com.gitlab.cdagaming.craftpresence.utils.world.DimensionUtils.getAllData(DimensionUtils.java:221)
[18:07:08] [CraftPresence-Dimension-Lookup/INFO] [STDERR/craftpresence]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at java.base/java.lang.Thread.run(Thread.java:1623)
```