### PR TITLE
Make Jet Engine fuel configurable

### DIFF
--- a/src/main/java/de/katzenpapst/amunra/AmunRa.java
+++ b/src/main/java/de/katzenpapst/amunra/AmunRa.java
@@ -13,6 +13,7 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.DimensionManager;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fluids.FluidRegistry;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -269,6 +270,8 @@ public class AmunRa {
 
         NetworkRegistry.INSTANCE.registerGuiHandler(AmunRa.instance, new GuiHandler());
         FMLCommonHandler.instance().bus().register(new TickHandlerServer());
+
+        TileEntityMothershipEngineJet.jetFuel = FluidRegistry.getFluid(config.validEngineFuel);
 
         // failsafes
         this.doCompatibilityChecks();

--- a/src/main/java/de/katzenpapst/amunra/config/ARConfig.java
+++ b/src/main/java/de/katzenpapst/amunra/config/ARConfig.java
@@ -51,6 +51,8 @@ public class ARConfig {
     // bodies which motherships cannot orbit
     public Set<String> mothershipBodiesNoOrbit;
 
+    public String validEngineFuel;
+
     // *** sky rendering and related ***
     // bodies not to render
     public Set<String> bodiesNoRender;
@@ -193,6 +195,9 @@ public class ARConfig {
                 "motherships",
                 emptySet,
                 "Bodies which should not be orbitable by motherships");
+
+        this.validEngineFuel = config
+                .getString("validEngineFuels", "motherships", "fuel", "These fluids can be used by Jet Engines");
 
         // mothershipUserRestriction = config.getBoolean("restrictMothershipToOwner", "mothership", true, "If true, only
         // the one who built the mothership will be able to use it. If false, anyone can");

--- a/src/main/java/de/katzenpapst/amunra/tile/TileEntityMothershipEngineJet.java
+++ b/src/main/java/de/katzenpapst/amunra/tile/TileEntityMothershipEngineJet.java
@@ -5,7 +5,6 @@ import net.minecraft.util.ResourceLocation;
 import net.minecraftforge.common.util.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidContainerRegistry;
-import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.IFluidContainerItem;
 
@@ -16,8 +15,6 @@ import de.katzenpapst.amunra.mothership.fueldisplay.MothershipFuelDisplayFluid;
 import de.katzenpapst.amunra.mothership.fueldisplay.MothershipFuelRequirements;
 import de.katzenpapst.amunra.proxy.ARSidedProxy.ParticleType;
 import micdoodle8.mods.galacticraft.api.vector.Vector3;
-import micdoodle8.mods.galacticraft.core.GalacticraftCore;
-import micdoodle8.mods.galacticraft.core.util.FluidUtil;
 import micdoodle8.mods.galacticraft.core.util.GCCoreUtil;
 
 /**
@@ -33,12 +30,13 @@ public class TileEntityMothershipEngineJet extends TileEntityMothershipEngineAbs
 
     // protected final MothershipFuel fuelType;
     protected MothershipFuelDisplay fuelType = null;
+    public static Fluid jetFuel;
 
     public TileEntityMothershipEngineJet() {
         this.boosterBlock = ARBlocks.blockMsEngineRocketBooster;
         this.containingItems = new ItemStack[1];
 
-        this.fuel = GalacticraftCore.fluidFuel;
+        this.fuel = jetFuel;
         this.fuelType = new MothershipFuelDisplayFluid(this.fuel);
     }
 
@@ -49,20 +47,14 @@ public class TileEntityMothershipEngineJet extends TileEntityMothershipEngineAbs
 
     @Override
     public void beginTransit(final long duration) {
-
         final MothershipFuelRequirements reqs = this.getFuelRequirements(duration);
-
         final int fuelReq = reqs.get(this.fuelType);
-
         this.fuelTank.drain(fuelReq, true);
-
         super.beginTransit(duration);
-
     }
 
     @Override
     protected boolean isItemFuel(final ItemStack itemstack) {
-
         FluidStack containedFluid = null;
         if (itemstack.getItem() instanceof IFluidContainerItem itemContainer) {
             containedFluid = itemContainer.getFluid(itemstack);
@@ -71,12 +63,8 @@ public class TileEntityMothershipEngineJet extends TileEntityMothershipEngineAbs
             containedFluid = FluidContainerRegistry.getFluidForFilledItem(itemstack);
         }
         if (containedFluid != null) {
-            if (containedFluid.getFluid() == this.fuel) {
-                return true;
-            }
-            return FluidUtil.testFuel(FluidRegistry.getFluidName(containedFluid));
+            return this.fuel == containedFluid.getFluid();
         }
-
         return false;
     }
 
@@ -96,7 +84,6 @@ public class TileEntityMothershipEngineJet extends TileEntityMothershipEngineAbs
 
     @Override
     protected void spawnParticles() {
-
         final Vector3 particleStart = this.getExhaustPosition(1);
         final Vector3 particleDirection = this.getExhaustDirection().scale(5);
 
@@ -113,13 +100,10 @@ public class TileEntityMothershipEngineJet extends TileEntityMothershipEngineAbs
 
     @Override
     public boolean canFill(final ForgeDirection from, final Fluid fluid) {
-
-        // here, fluid is fuel
-        if (!FluidUtil.testFuel(FluidRegistry.getFluidName(fluid))) {
-            return false;
+        if (this.fuel == fluid) {
+            return super.canFill(from, fluid);
         }
-
-        return super.canFill(from, fluid);
+        return false;
     }
 
     @Override


### PR DESCRIPTION
The actual fuel to be used can be decided on later (this could be used for balancing/gating purposes if we want that).