### PR TITLE
Add compat to electricity/fluid slots

### DIFF
--- a/src/main/java/de/katzenpapst/amunra/inventory/ContainerArtificalGravity.java
+++ b/src/main/java/de/katzenpapst/amunra/inventory/ContainerArtificalGravity.java
@@ -5,14 +5,14 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.tileentity.TileEntity;
 
-import micdoodle8.mods.galacticraft.core.energy.item.ItemElectricBase;
+import micdoodle8.mods.galacticraft.api.item.IItemElectric;
 import micdoodle8.mods.galacticraft.core.inventory.SlotSpecific;
 
 public class ContainerArtificalGravity extends ContainerWithPlayerInventory {
 
     public ContainerArtificalGravity(final InventoryPlayer playerInv, final IInventory tile) {
         super(tile);
-        this.addSlotToContainer(new SlotSpecific(tile, 0, 152, 132, ItemElectricBase.class));
+        this.addSlotToContainer(new SlotSpecific(tile, 0, 152, 132, IItemElectric.class));
         this.initPlayerInventorySlots(playerInv, 35);
     }
 

--- a/src/main/java/de/katzenpapst/amunra/inventory/ContainerAtomBattery.java
+++ b/src/main/java/de/katzenpapst/amunra/inventory/ContainerAtomBattery.java
@@ -4,14 +4,14 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
 
 import de.katzenpapst.amunra.tile.TileEntityIsotopeGenerator;
-import micdoodle8.mods.galacticraft.core.energy.item.ItemElectricBase;
+import micdoodle8.mods.galacticraft.api.item.IItemElectric;
 import micdoodle8.mods.galacticraft.core.inventory.SlotSpecific;
 
 public class ContainerAtomBattery extends ContainerWithPlayerInventory {
 
     public ContainerAtomBattery(final InventoryPlayer par1InventoryPlayer, final TileEntityIsotopeGenerator solarGen) {
         super(solarGen);
-        this.addSlotToContainer(new SlotSpecific(solarGen, 0, 152, 83, ItemElectricBase.class));
+        this.addSlotToContainer(new SlotSpecific(solarGen, 0, 152, 83, IItemElectric.class));
         this.initPlayerInventorySlots(par1InventoryPlayer);
     }
 

--- a/src/main/java/de/katzenpapst/amunra/inventory/ContainerHydroponics.java
+++ b/src/main/java/de/katzenpapst/amunra/inventory/ContainerHydroponics.java
@@ -6,7 +6,7 @@ import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 
 import de.katzenpapst.amunra.tile.TileEntityHydroponics;
-import micdoodle8.mods.galacticraft.core.energy.item.ItemElectricBase;
+import micdoodle8.mods.galacticraft.api.item.IItemElectric;
 import micdoodle8.mods.galacticraft.core.inventory.SlotSpecific;
 
 public class ContainerHydroponics extends ContainerWithPlayerInventory {
@@ -14,7 +14,7 @@ public class ContainerHydroponics extends ContainerWithPlayerInventory {
     public ContainerHydroponics(final InventoryPlayer player, final TileEntityHydroponics tile) {
         super(tile);
 
-        this.addSlotToContainer(new SlotSpecific(tile, 0, 32, 27, ItemElectricBase.class));
+        this.addSlotToContainer(new SlotSpecific(tile, 0, 32, 27, IItemElectric.class));
 
         final SlotSpecific secondarySlot = new SlotSpecific(
                 tile,

--- a/src/main/java/de/katzenpapst/amunra/inventory/ContainerIonEngine.java
+++ b/src/main/java/de/katzenpapst/amunra/inventory/ContainerIonEngine.java
@@ -3,7 +3,7 @@ package de.katzenpapst.amunra.inventory;
 import net.minecraft.entity.player.InventoryPlayer;
 
 import de.katzenpapst.amunra.tile.TileEntityMothershipEngineAbstract;
-import micdoodle8.mods.galacticraft.core.energy.item.ItemElectricBase;
+import micdoodle8.mods.galacticraft.api.item.IItemElectric;
 import micdoodle8.mods.galacticraft.core.inventory.SlotSpecific;
 
 public class ContainerIonEngine extends ContainerRocketEngine {
@@ -16,7 +16,7 @@ public class ContainerIonEngine extends ContainerRocketEngine {
     @Override
     protected void initSlots(final TileEntityMothershipEngineAbstract tile) {
         super.initSlots(tile);
-        this.addSlotToContainer(new SlotSpecific(tile, 1, 152, 86, ItemElectricBase.class));
+        this.addSlotToContainer(new SlotSpecific(tile, 1, 152, 86, IItemElectric.class));
     }
 
 }

--- a/src/main/java/de/katzenpapst/amunra/inventory/ContainerRocketEngine.java
+++ b/src/main/java/de/katzenpapst/amunra/inventory/ContainerRocketEngine.java
@@ -2,11 +2,14 @@ package de.katzenpapst.amunra.inventory;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.Slot;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemBucket;
-import net.minecraftforge.fluids.ItemFluidContainer;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.fluids.FluidContainerRegistry;
+import net.minecraftforge.fluids.IFluidContainerItem;
 
 import de.katzenpapst.amunra.tile.TileEntityMothershipEngineAbstract;
-import micdoodle8.mods.galacticraft.core.inventory.SlotSpecific;
 
 public class ContainerRocketEngine extends ContainerWithPlayerInventory {
 
@@ -26,7 +29,15 @@ public class ContainerRocketEngine extends ContainerWithPlayerInventory {
     }
 
     protected void initSlots(final TileEntityMothershipEngineAbstract tile) {
-        this.addSlotToContainer(new SlotSpecific(tile, 0, 8, 7, ItemFluidContainer.class, ItemBucket.class));
+        this.addSlotToContainer(new Slot(tile, 0, 8, 7) {
+
+            @Override
+            public boolean isItemValid(ItemStack stack) {
+                final Item item = stack.getItem();
+                return item instanceof IFluidContainerItem || item instanceof ItemBucket
+                        || FluidContainerRegistry.isContainer(stack);
+            }
+        });
     }
 
     @Override

--- a/src/main/java/de/katzenpapst/amunra/inventory/ContainerWithPlayerInventory.java
+++ b/src/main/java/de/katzenpapst/amunra/inventory/ContainerWithPlayerInventory.java
@@ -38,12 +38,6 @@ abstract public class ContainerWithPlayerInventory extends Container {
         }
     }
 
-    // let's try to fix shiftclicking
-    @Override
-    protected Slot addSlotToContainer(Slot p_75146_1_) {
-        return super.addSlotToContainer(p_75146_1_);
-    }
-
     protected boolean mergeSingleSlot(final ItemStack mergeFrom, final Slot slotToMergeTo) {
 
         final ItemStack targetStack = slotToMergeTo.getStack();


### PR DESCRIPTION
Make Amun-Ra GUIs compatible with GT (and others).

`IItemElectric` is a magic class wich tells `SlotSpecific` to accept various electric items, not just the ones which extend that class ([source](https://github.com/GTNewHorizons/Galacticraft/blob/master/src/main/java/micdoodle8/mods/galacticraft/core/inventory/SlotSpecific.java#L36-L73)).

Rocket Engines now accept all fluid containers.