### PR TITLE
Fix oredict for spodumene ore

### DIFF
--- a/src/main/java/de/katzenpapst/amunra/block/ARBlocks.java
+++ b/src/main/java/de/katzenpapst/amunra/block/ARBlocks.java
@@ -268,7 +268,7 @@ public class ARBlocks {
         subLapis = (SubBlockOre) new SubBlockOre("oreLapis", "amunra:ore-lapis").setOredictNames("oreLapis")
                 .setHarvestInfo("pickaxe", 1).setHardness(3).setResistance(5);
 
-        subLithium = (SubBlockOre) new SubBlockOre("oreLithium", "amunra:ore-lithium").setOredictNames("oreLithium")
+        subLithium = (SubBlockOre) new SubBlockOre("oreLithium", "amunra:ore-lithium").setOredictNames("oreSpodumene")
                 .setHarvestInfo("pickaxe", 3).setHardness(3).setResistance(5);
 
         subRuby = (SubBlockOre) new SubBlockOre("oreRuby", "amunra:ore-ruby").setOredictNames("oreRuby")


### PR DESCRIPTION
just fixes the oredict for the 2 spodumene ores, was tagged as lithium by mistake (probably because all the internal variables use that name lol).

![image](https://github.com/GTNewHorizons/amunra/assets/40274384/0febd222-8c39-426b-98dc-b2cf62c61b71)
