### PR TITLE
Fix all Players not on a Mothership being kicked if it ends Transit

### DIFF
--- a/src/main/java/de/katzenpapst/amunra/network/packet/PacketSimpleAR.java
+++ b/src/main/java/de/katzenpapst/amunra/network/packet/PacketSimpleAR.java
@@ -371,7 +371,12 @@ public class PacketSimpleAR extends Packet implements IPacket {
             case C_MOTHERSHIP_TRANSIT_ENDED: // (Side.CLIENT, Integer.class);
                 motherShip = mData.getByMothershipId((int) this.data.get(0));
 
-                motherShip.getWorldProviderClient().endTransit();
+                MothershipWorldProvider mswp = motherShip.getWorldProviderClient();
+                if (mswp == null) {
+                    // this player is not on the mothership
+                    break;
+                }
+                mswp.endTransit();
 
                 if (FMLClientHandler.instance()
                         .getClient().currentScreen instanceof GuiShuttleSelection guiShuttleSelection) {


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13737

`Mothership#getWorldProviderClient` only returns an instance of `MothershipWorldProvider` if the player is in that Mothership dimension, otherwise it returns null. Thus, all clients not on the arriving Mothership receive an NPE:
```log
[Client thread/ERROR]: There was a critical exception handling a packet on channel amunra$generic
java.lang.NullPointerException: Cannot invoke "de.katzenpapst.amunra.mothership.MothershipWorldProvider.endTransit()" because the return value of "de.katzenpapst.amunra.mothership.Mothership.getWorldProviderClient()" is null
	at de.katzenpapst.amunra.network.packet.PacketSimpleAR.handleClientSide(PacketSimpleAR.java:374) ~[PacketSimpleAR.class:?]
	at de.katzenpapst.amunra.network.ARPacketHandler.channelRead0(ARPacketHandler.java:24) ~[ARPacketHandler.class:?]
	at de.katzenpapst.amunra.network.ARPacketHandler.channelRead0(ARPacketHandler.java:14) ~[ARPacketHandler.class:?]
	at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:98) ~[SimpleChannelInboundHandler.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) ~[DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) ~[DefaultChannelHandlerContext.class:?]
	at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[MessageToMessageDecoder.class:?]
	at io.netty.handler.codec.MessageToMessageCodec.channelRead(MessageToMessageCodec.java:111) ~[MessageToMessageCodec.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.invokeChannelRead(DefaultChannelHandlerContext.java:337) ~[DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelHandlerContext.fireChannelRead(DefaultChannelHandlerContext.java:323) ~[DefaultChannelHandlerContext.class:?]
	at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:785) ~[DefaultChannelPipeline.class:?]
	at io.netty.channel.embedded.EmbeddedChannel.writeInbound(EmbeddedChannel.java:169) ~[EmbeddedChannel.class:?]
	at cpw.mods.fml.common.network.internal.FMLProxyPacket.processPacket(FMLProxyPacket.java:86) [FMLProxyPacket.class:?]
	at net.minecraft.network.NetworkManager.processReceivedPackets(NetworkManager.java:241) [NetworkManager.class:?]
	at net.minecraft.client.multiplayer.PlayerControllerMP.updateController(PlayerControllerMP.java:317) [PlayerControllerMP.class:?]
	at net.minecraft.client.Minecraft.runTick(Minecraft.java:1693) [Minecraft.class:?]
	at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1039) [Minecraft.class:?]
	at net.minecraft.client.Minecraft.run(Minecraft.java:962) [Minecraft.class:?]
	at net.minecraft.client.main.Main.main(Main.java:164) [Main.class:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77) ~[?:?]
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.base/java.lang.reflect.Method.invoke(Method.java:568) ~[?:?]
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:165) [launchwrapper-1.15.jar:?]
	at net.minecraft.launchwrapper.Launch.main(Launch.java:29) [launchwrapper-1.15.jar:?]
	at net.minecraftforge.gradle.GradleStartCommon.launch(GradleStartCommon.java:97) [mclauncher-1.7.10.jar:?]
	at GradleStart.main(GradleStart.java:40) [mclauncher-1.7.10.jar:?]
```