### PR TITLE
Remove offline kick if hodgepodge is loaded

### DIFF
--- a/src/main/java/de/katzenpapst/amunra/AmunRa.java
+++ b/src/main/java/de/katzenpapst/amunra/AmunRa.java
@@ -108,7 +108,8 @@ import micdoodle8.mods.galacticraft.planets.asteroids.items.AsteroidsItems;
         dependencies = "required-after:GalacticraftCore@[3.0.61-GTNH,);" + "required-after:GalacticraftMars;"
                 + "after:dreamcraft;"
                 + "after:IronChest;"
-                + "after:AdvancedSolarPanel",
+                + "after:AdvancedSolarPanel;"
+                + "after:Hodgepodge@[2.2.19,);",
         name = AmunRa.MODNAME)
 public class AmunRa {
 

--- a/src/main/java/de/katzenpapst/amunra/proxy/ServerProxy.java
+++ b/src/main/java/de/katzenpapst/amunra/proxy/ServerProxy.java
@@ -3,6 +3,7 @@ package de.katzenpapst.amunra.proxy;
 import net.minecraft.server.MinecraftServer;
 
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import de.katzenpapst.amunra.AmunRa;
 
@@ -12,7 +13,9 @@ public class ServerProxy extends ARSidedProxy {
     public void init(final FMLInitializationEvent event) {
         try {
             final MinecraftServer s = MinecraftServer.getServer();
-            if (s.isDedicatedServer() && !s.isServerInOnlineMode() && !AmunRa.isDevEnvironment()) {
+            if (!Loader.isModLoaded("hodgepodge") && s.isDedicatedServer()
+                    && !s.isServerInOnlineMode()
+                    && !AmunRa.isDevEnvironment()) {
                 AmunRa.LOGGER.fatal("Server is running in offline mode. This is not supported.");
                 FMLCommonHandler.instance().exitJava(-10, false);
             }


### PR DESCRIPTION
[Hodgepodge#221](https://github.com/GTNewHorizons/Hodgepodge/pull/221) added offline uuid mapping that requires the server to have been online before and an online user connected before letting them connect offline.