### PR TITLE
Add missing @SideOnly

### DIFF
--- a/src/main/java/de/katzenpapst/amunra/item/ItemBasicMulti.java
+++ b/src/main/java/de/katzenpapst/amunra/item/ItemBasicMulti.java
@@ -96,6 +96,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public EnumRarity getRarity(ItemStack p_77613_1_) {
         return ClientProxyCore.galacticraftItem;
     }

--- a/src/main/java/de/katzenpapst/amunra/item/ItemJet.java
+++ b/src/main/java/de/katzenpapst/amunra/item/ItemJet.java
@@ -43,6 +43,7 @@ public class ItemJet extends ItemBlockMulti {
         return this.field_150939_a.getUnlocalizedName();
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
     public EnumRarity getRarity(ItemStack p_77613_1_) {
         // colors the name

--- a/src/main/java/de/katzenpapst/amunra/item/ItemThermalSuit.java
+++ b/src/main/java/de/katzenpapst/amunra/item/ItemThermalSuit.java
@@ -75,6 +75,7 @@ public class ItemThermalSuit extends Item implements IItemThermal {
     }
 
     @Override
+    @SideOnly(Side.CLIENT)
     public EnumRarity getRarity(ItemStack p_77613_1_) {
         return ClientProxyCore.galacticraftItem;
     }

--- a/src/main/java/de/katzenpapst/amunra/item/SubItem.java
+++ b/src/main/java/de/katzenpapst/amunra/item/SubItem.java
@@ -5,6 +5,8 @@ import net.minecraft.item.EnumRarity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import de.katzenpapst.amunra.AmunRa;
 import micdoodle8.mods.galacticraft.core.proxy.ClientProxyCore;
 
@@ -38,6 +40,7 @@ public class SubItem extends Item {
         return AmunRa.arTab;
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
     public EnumRarity getRarity(ItemStack p_77613_1_) {
         return ClientProxyCore.galacticraftItem;


### PR DESCRIPTION
getRarity=func_77613_e
micdoodle8.mods.galacticraft.core.proxy.ClientProxyCore is client only
fix
```
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: java.lang.NoClassDefFoundError: net/minecraft/client/entity/EntityClientPlayerMP
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//de.katzenpapst.amunra.item.ItemJet.func_77613_e(ItemJet.java:49)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//com.enderio.core.common.transform.EnderCoreMethods.getItemRarity(EnderCoreMethods.java:43)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.item.ItemStack.func_77953_t(ItemStack.java)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.item.ItemStack.func_151000_E(ItemStack.java:766)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.cluster.implementations.CraftingCPUCluster$CraftNotification.createMessage(CraftingCPUCluster.java:1682)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.cluster.implementations.CraftingCPUCluster.lambda$new$1ae9d77$1(CraftingCPUCluster.java:171)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.cluster.implementations.CraftingCPUCluster.lambda$completeJob$1(CraftingCPUCluster.java:509)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.cluster.implementations.CraftingCPUCluster.completeJob(CraftingCPUCluster.java:509)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.cluster.implementations.CraftingCPUCluster.injectItems(CraftingCPUCluster.java:405)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.cache.CraftingGridCache.injectItems(CraftingGridCache.java:409)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.storage.NetworkInventoryHandler.injectItems(NetworkInventoryHandler.java:112)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.cache.NetworkMonitor.injectItems(NetworkMonitor.java:142)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.storage.MEPassThrough.injectItems(MEPassThrough.java:44)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.storage.MEInventoryHandler.injectItems(MEInventoryHandler.java:100)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.storage.NetworkInventoryHandler.injectItems(NetworkInventoryHandler.java:172)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.me.cache.NetworkMonitor.injectItems(NetworkMonitor.java:142)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//appeng.util.Platform.poweredInsert(Platform.java:1329)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//gregtech.common.tileentities.machines.MTEHatchOutputBusME.flushCachedStack(MTEHatchOutputBusME.java:275)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//gregtech.common.tileentities.machines.MTEHatchOutputBusME.onPostTick(MTEHatchOutputBusME.java:304)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//gregtech.api.metatileentity.BaseMetaTileEntity.func_145845_h(BaseMetaTileEntity.java:566)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.world.World.redirect$zzo000$laggoggles$measureUpdateEntity(World.java:60636)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.world.World.func_72939_s(World.java:1939)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.world.WorldServer.func_72939_s(WorldServer.java:489)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:636)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:334)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: Caused by: java.lang.ClassNotFoundException: net.minecraft.client.entity.EntityClientPlayerMP in invalid class cache
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at System//net.minecraft.launchwrapper.LaunchClassLoader.findClass(LaunchClassLoader.java:214)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:593)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
[18:47:05] [Server thread/INFO] [STDERR/]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	... 29 more
```