### PR TITLE
Protect against hard crashes for invalid meta items/blocks

### DIFF
--- a/src/main/java/de/katzenpapst/amunra/block/BlockBasicMeta.java
+++ b/src/main/java/de/katzenpapst/amunra/block/BlockBasicMeta.java
@@ -106,7 +106,7 @@ public class BlockBasicMeta extends Block implements IMetaBlock, IDetectableReso
 
     @Override
     public SubBlock getSubBlock(final int meta) {
-        if(meta < 0 || meta >= subBlocksArray.length){
+        if (meta < 0 || meta >= subBlocksArray.length) {
             return null;
         }
         return this.subBlocksArray[this.getDistinctionMeta(meta)];

--- a/src/main/java/de/katzenpapst/amunra/block/BlockBasicMeta.java
+++ b/src/main/java/de/katzenpapst/amunra/block/BlockBasicMeta.java
@@ -106,6 +106,9 @@ public class BlockBasicMeta extends Block implements IMetaBlock, IDetectableReso
 
     @Override
     public SubBlock getSubBlock(final int meta) {
+        if(meta < 0 || meta >= subBlocksArray.length){
+            return null;
+        }
         return this.subBlocksArray[this.getDistinctionMeta(meta)];
     }
 

--- a/src/main/java/de/katzenpapst/amunra/client/renderer/BlockRendererMultiOre.java
+++ b/src/main/java/de/katzenpapst/amunra/client/renderer/BlockRendererMultiOre.java
@@ -28,7 +28,7 @@ public class BlockRendererMultiOre implements ISimpleBlockRenderingHandler {
 
         // and then the overlay
         final SubBlock sb = ((BlockOreMulti) block).getSubBlock(metadata);
-        if(sb != null){
+        if (sb != null) {
             drawBlock(sb, metadata, renderer);
         }
 
@@ -46,7 +46,7 @@ public class BlockRendererMultiOre implements ISimpleBlockRenderingHandler {
         renderer.renderStandardBlock(block, x, y, z);
 
         // block with the overlay
-        if(sb != null){
+        if (sb != null) {
             renderer.renderStandardBlock(sb, x, y, z);
         }
 

--- a/src/main/java/de/katzenpapst/amunra/client/renderer/BlockRendererMultiOre.java
+++ b/src/main/java/de/katzenpapst/amunra/client/renderer/BlockRendererMultiOre.java
@@ -28,7 +28,9 @@ public class BlockRendererMultiOre implements ISimpleBlockRenderingHandler {
 
         // and then the overlay
         final SubBlock sb = ((BlockOreMulti) block).getSubBlock(metadata);
-        drawBlock(sb, metadata, renderer);
+        if(sb != null){
+            drawBlock(sb, metadata, renderer);
+        }
 
         GL11.glTranslatef(0.5F, 0.5F, 0.5F);
 
@@ -44,7 +46,9 @@ public class BlockRendererMultiOre implements ISimpleBlockRenderingHandler {
         renderer.renderStandardBlock(block, x, y, z);
 
         // block with the overlay
-        renderer.renderStandardBlock(sb, x, y, z);
+        if(sb != null){
+            renderer.renderStandardBlock(sb, x, y, z);
+        }
 
         return true;
     }

--- a/src/main/java/de/katzenpapst/amunra/item/ItemBasicMulti.java
+++ b/src/main/java/de/katzenpapst/amunra/item/ItemBasicMulti.java
@@ -114,18 +114,30 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
 
     @Override
     public String getUnlocalizedName(ItemStack stack) {
+        SubItem subItem = this.getSubItem(stack.getItemDamage());
+        if(subItem == null){
+            return getUnlocalizedName();
+        }
         return this.getUnlocalizedName() + "." + this.getSubItem(stack.getItemDamage()).getUnlocalizedName();
     }
 
     @Override
     @SideOnly(Side.CLIENT)
-    public IIcon getIconFromDamage(int p_77617_1_) {
-        return this.subItems.get(p_77617_1_).getIconFromDamage(0);
+    public IIcon getIconFromDamage(int damage) {
+        SubItem subItem = this.getSubItem(damage);
+        if(subItem == null){
+            return null;
+        }
+        return subItem.getIconFromDamage(0);
     }
 
     @Override
     public IIcon getIcon(ItemStack stack, int pass) {
-        return this.subItems.get(stack.getItemDamage()).getIcon(stack, pass);
+        SubItem subItem = this.getSubItem(stack.getItemDamage());
+        if(subItem == null){
+            return null;
+        }
+        return subItem.getIcon(stack, pass);
     }
 
     /**
@@ -133,8 +145,12 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
      */
     @Override
     @SideOnly(Side.CLIENT)
-    public IIcon getIconIndex(ItemStack p_77650_1_) {
-        return this.subItems.get(p_77650_1_.getItemDamage()).getIconIndex(p_77650_1_);
+    public IIcon getIconIndex(ItemStack stack) {
+        SubItem subItem = this.getSubItem(stack.getItemDamage());
+        if(subItem == null){
+            return null;
+        }
+        return subItem.getIconIndex(stack);
     }
 
     @Override
@@ -152,8 +168,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
 
     public SubItem getSubItem(final int damage) {
         if (damage >= this.subItems.size() || this.subItems.get(damage) == null) {
-            throw new IllegalArgumentException(
-                    "Requested invalid SubItem " + damage + " from " + this.getUnlocalizedName());
+            return null;
         }
         return this.subItems.get(damage);
     }
@@ -164,43 +179,69 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
             boolean p_77624_4_) {
         final SubItem item = this.getSubItem(p_77624_1_.getItemDamage());
 
-        item.addInformation(p_77624_1_, p_77624_2_, p_77624_3_, p_77624_4_);
+        if(item != null){
+            item.addInformation(p_77624_1_, p_77624_2_, p_77624_3_, p_77624_4_);
 
-        String info = item.getItemInfo();
-        if (info != null) {
-            info = GCCoreUtil.translate(info);
-            p_77624_3_
+            String info = item.getItemInfo();
+            if (info != null) {
+                info = GCCoreUtil.translate(info);
+                p_77624_3_
                     .addAll(FMLClientHandler.instance().getClient().fontRenderer.listFormattedStringToWidth(info, 150));
+            }
         }
     }
 
     @Override
-    public ItemStack onEaten(ItemStack p_77654_1_, World p_77654_2_, EntityPlayer p_77654_3_) {
-        return this.getSubItem(p_77654_1_.getItemDamage()).onEaten(p_77654_1_, p_77654_2_, p_77654_3_);
+    public ItemStack onEaten(ItemStack stack, World world, EntityPlayer player) {
+        SubItem subItem = this.getSubItem(stack.getItemDamage());
+        if(subItem == null){
+            return super.onEaten(stack, world, player);
+        }
+        return subItem.onEaten(stack, world, player);
     }
 
     @Override
-    public int getMaxItemUseDuration(ItemStack p_77626_1_) {
-        return this.getSubItem(p_77626_1_.getItemDamage()).getMaxItemUseDuration(p_77626_1_);
+    public int getMaxItemUseDuration(ItemStack stack) {
+        SubItem subItem = this.getSubItem(stack.getItemDamage());
+        if(subItem == null){
+            return super.getMaxItemUseDuration(stack);
+        }
+        return subItem.getMaxItemUseDuration(stack);
     }
 
     @Override
     public EnumAction getItemUseAction(ItemStack stack) {
-        return this.getSubItem(stack.getItemDamage()).getItemUseAction(stack);
+        SubItem subItem = this.getSubItem(stack.getItemDamage());
+        if(subItem == null){
+            return super.getItemUseAction(stack);
+        }
+        return subItem.getItemUseAction(stack);
     }
 
     @Override
     public ItemStack onItemRightClick(ItemStack itemStackIn, World worldIn, EntityPlayer player) {
-        return this.getSubItem(itemStackIn.getItemDamage()).onItemRightClick(itemStackIn, worldIn, player);
+        SubItem subItem = this.getSubItem(itemStackIn.getItemDamage());
+        if(subItem == null){
+            return super.onItemRightClick(itemStackIn, worldIn, player);
+        }
+        return subItem.onItemRightClick(itemStackIn, worldIn, player);
     }
 
     @Override
     public boolean onLeftClickEntity(ItemStack stack, EntityPlayer player, Entity entity) {
-        return this.getSubItem(stack.getItemDamage()).onLeftClickEntity(stack, player, entity);
+        SubItem subItem = this.getSubItem(stack.getItemDamage());
+        if(subItem == null){
+            return super.onLeftClickEntity(stack, player, entity);
+        }
+        return subItem.onLeftClickEntity(stack, player, entity);
     }
 
     public int getFuelDuration(final int meta) {
-        return this.getSubItem(meta).getFuelDuration();
+        SubItem subItem = this.getSubItem(meta);
+        if(subItem == null){
+            return 0;
+        }
+        return subItem.getFuelDuration();
     }
 
     @Override

--- a/src/main/java/de/katzenpapst/amunra/item/ItemBasicMulti.java
+++ b/src/main/java/de/katzenpapst/amunra/item/ItemBasicMulti.java
@@ -115,7 +115,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
     @Override
     public String getUnlocalizedName(ItemStack stack) {
         SubItem subItem = this.getSubItem(stack.getItemDamage());
-        if(subItem == null){
+        if (subItem == null) {
             return getUnlocalizedName();
         }
         return this.getUnlocalizedName() + "." + this.getSubItem(stack.getItemDamage()).getUnlocalizedName();
@@ -125,7 +125,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
     @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamage(int damage) {
         SubItem subItem = this.getSubItem(damage);
-        if(subItem == null){
+        if (subItem == null) {
             return null;
         }
         return subItem.getIconFromDamage(0);
@@ -134,7 +134,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
     @Override
     public IIcon getIcon(ItemStack stack, int pass) {
         SubItem subItem = this.getSubItem(stack.getItemDamage());
-        if(subItem == null){
+        if (subItem == null) {
             return null;
         }
         return subItem.getIcon(stack, pass);
@@ -147,7 +147,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
     @SideOnly(Side.CLIENT)
     public IIcon getIconIndex(ItemStack stack) {
         SubItem subItem = this.getSubItem(stack.getItemDamage());
-        if(subItem == null){
+        if (subItem == null) {
             return null;
         }
         return subItem.getIconIndex(stack);
@@ -179,14 +179,14 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
             boolean p_77624_4_) {
         final SubItem item = this.getSubItem(p_77624_1_.getItemDamage());
 
-        if(item != null){
+        if (item != null) {
             item.addInformation(p_77624_1_, p_77624_2_, p_77624_3_, p_77624_4_);
 
             String info = item.getItemInfo();
             if (info != null) {
                 info = GCCoreUtil.translate(info);
-                p_77624_3_
-                    .addAll(FMLClientHandler.instance().getClient().fontRenderer.listFormattedStringToWidth(info, 150));
+                p_77624_3_.addAll(
+                        FMLClientHandler.instance().getClient().fontRenderer.listFormattedStringToWidth(info, 150));
             }
         }
     }
@@ -194,7 +194,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
     @Override
     public ItemStack onEaten(ItemStack stack, World world, EntityPlayer player) {
         SubItem subItem = this.getSubItem(stack.getItemDamage());
-        if(subItem == null){
+        if (subItem == null) {
             return super.onEaten(stack, world, player);
         }
         return subItem.onEaten(stack, world, player);
@@ -203,7 +203,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
     @Override
     public int getMaxItemUseDuration(ItemStack stack) {
         SubItem subItem = this.getSubItem(stack.getItemDamage());
-        if(subItem == null){
+        if (subItem == null) {
             return super.getMaxItemUseDuration(stack);
         }
         return subItem.getMaxItemUseDuration(stack);
@@ -212,7 +212,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
     @Override
     public EnumAction getItemUseAction(ItemStack stack) {
         SubItem subItem = this.getSubItem(stack.getItemDamage());
-        if(subItem == null){
+        if (subItem == null) {
             return super.getItemUseAction(stack);
         }
         return subItem.getItemUseAction(stack);
@@ -221,7 +221,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
     @Override
     public ItemStack onItemRightClick(ItemStack itemStackIn, World worldIn, EntityPlayer player) {
         SubItem subItem = this.getSubItem(itemStackIn.getItemDamage());
-        if(subItem == null){
+        if (subItem == null) {
             return super.onItemRightClick(itemStackIn, worldIn, player);
         }
         return subItem.onItemRightClick(itemStackIn, worldIn, player);
@@ -230,7 +230,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
     @Override
     public boolean onLeftClickEntity(ItemStack stack, EntityPlayer player, Entity entity) {
         SubItem subItem = this.getSubItem(stack.getItemDamage());
-        if(subItem == null){
+        if (subItem == null) {
             return super.onLeftClickEntity(stack, player, entity);
         }
         return subItem.onLeftClickEntity(stack, player, entity);
@@ -238,7 +238,7 @@ public class ItemBasicMulti extends Item implements ItemBlockDesc.IBlockShiftDes
 
     public int getFuelDuration(final int meta) {
         SubItem subItem = this.getSubItem(meta);
-        if(subItem == null){
+        if (subItem == null) {
             return 0;
         }
         return subItem.getFuelDuration();

--- a/src/main/java/de/katzenpapst/amunra/item/ItemBlockMulti.java
+++ b/src/main/java/de/katzenpapst/amunra/item/ItemBlockMulti.java
@@ -1,6 +1,5 @@
 package de.katzenpapst.amunra.item;
 
-import de.katzenpapst.amunra.block.SubBlock;
 import net.minecraft.block.Block;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemStack;
@@ -9,6 +8,7 @@ import net.minecraft.util.IIcon;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
 import de.katzenpapst.amunra.block.IMetaBlock;
+import de.katzenpapst.amunra.block.SubBlock;
 import micdoodle8.mods.galacticraft.core.items.ItemBlockDesc;
 import micdoodle8.mods.galacticraft.core.proxy.ClientProxyCore;
 
@@ -53,7 +53,7 @@ public class ItemBlockMulti extends ItemBlockDesc {
     @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamage(int p_77617_1_) {
         SubBlock sb = ((IMetaBlock) this.field_150939_a).getSubBlock(p_77617_1_);
-        if(sb == null){
+        if (sb == null) {
             return null;
         }
         return sb.getIcon(1, 0);

--- a/src/main/java/de/katzenpapst/amunra/item/ItemBlockMulti.java
+++ b/src/main/java/de/katzenpapst/amunra/item/ItemBlockMulti.java
@@ -1,5 +1,6 @@
 package de.katzenpapst.amunra.item;
 
+import de.katzenpapst.amunra.block.SubBlock;
 import net.minecraft.block.Block;
 import net.minecraft.item.EnumRarity;
 import net.minecraft.item.ItemStack;
@@ -13,7 +14,7 @@ import micdoodle8.mods.galacticraft.core.proxy.ClientProxyCore;
 
 /**
  * Item for multiblocks
- * 
+ *
  * @author katzenpapst
  */
 public class ItemBlockMulti extends ItemBlockDesc {
@@ -51,6 +52,10 @@ public class ItemBlockMulti extends ItemBlockDesc {
     @Override
     @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamage(int p_77617_1_) {
-        return ((IMetaBlock) this.field_150939_a).getSubBlock(p_77617_1_).getIcon(1, 0);
+        SubBlock sb = ((IMetaBlock) this.field_150939_a).getSubBlock(p_77617_1_);
+        if(sb == null){
+            return null;
+        }
+        return sb.getIcon(1, 0);
     }
 }

--- a/src/main/java/de/katzenpapst/amunra/item/ItemJet.java
+++ b/src/main/java/de/katzenpapst/amunra/item/ItemJet.java
@@ -79,8 +79,7 @@ public class ItemJet extends ItemBlockMulti {
     @Override
     @SideOnly(Side.CLIENT)
     public IIcon getIconFromDamage(int damage) {
-        if(damage < 0 || damage >= icons.length)
-            return null;
+        if (damage < 0 || damage >= icons.length) return null;
         return this.icons[damage];
         // return ((BlockMachineMeta)field_150939_a).getSubBlock(dmg).getIcon(1, 0);
     }

--- a/src/main/java/de/katzenpapst/amunra/item/ItemJet.java
+++ b/src/main/java/de/katzenpapst/amunra/item/ItemJet.java
@@ -78,8 +78,10 @@ public class ItemJet extends ItemBlockMulti {
 
     @Override
     @SideOnly(Side.CLIENT)
-    public IIcon getIconFromDamage(int p_77617_1_) {
-        return this.icons[p_77617_1_];
+    public IIcon getIconFromDamage(int damage) {
+        if(damage < 0 || damage >= icons.length)
+            return null;
+        return this.icons[damage];
         // return ((BlockMachineMeta)field_150939_a).getSubBlock(dmg).getIcon(1, 0);
     }
 

--- a/src/main/java/de/katzenpapst/amunra/item/ItemThermalSuit.java
+++ b/src/main/java/de/katzenpapst/amunra/item/ItemThermalSuit.java
@@ -90,12 +90,19 @@ public class ItemThermalSuit extends Item implements IItemThermal {
 
     @Override
     public String getUnlocalizedName(ItemStack stack) {
-        return this.getUnlocalizedName() + "." + this.names[stack.getItemDamage()];
+        int damage = stack.getItemDamage();
+        if(damage < 0 || damage >= this.names.length){
+            return this.getUnlocalizedName();
+        }
+        return this.getUnlocalizedName() + "." + this.names[damage];
     }
 
     @Override
-    public IIcon getIconFromDamage(int p_77617_1_) {
-        return this.icons[p_77617_1_];
+    public IIcon getIconFromDamage(int damage) {
+        if(damage < 0 || damage >= this.icons.length){
+            return null;
+        }
+        return this.icons[damage];
     }
 
     @Override

--- a/src/main/java/de/katzenpapst/amunra/item/ItemThermalSuit.java
+++ b/src/main/java/de/katzenpapst/amunra/item/ItemThermalSuit.java
@@ -91,7 +91,7 @@ public class ItemThermalSuit extends Item implements IItemThermal {
     @Override
     public String getUnlocalizedName(ItemStack stack) {
         int damage = stack.getItemDamage();
-        if(damage < 0 || damage >= this.names.length){
+        if (damage < 0 || damage >= this.names.length) {
             return this.getUnlocalizedName();
         }
         return this.getUnlocalizedName() + "." + this.names[damage];
@@ -99,7 +99,7 @@ public class ItemThermalSuit extends Item implements IItemThermal {
 
     @Override
     public IIcon getIconFromDamage(int damage) {
-        if(damage < 0 || damage >= this.icons.length){
+        if (damage < 0 || damage >= this.icons.length) {
             return null;
         }
         return this.icons[damage];


### PR DESCRIPTION
Adds various out-of-bounds and null checks to make sure if the player somehow obtains an item/block with an invalid meta, it doesn't hard crash the game and soft-lock the world

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23684