### PR TITLE
add isUseableByPlayer to TileEntityGravitation

### DIFF
--- a/src/main/java/de/katzenpapst/amunra/tile/TileEntityGravitation.java
+++ b/src/main/java/de/katzenpapst/amunra/tile/TileEntityGravitation.java
@@ -343,4 +343,9 @@ public class TileEntityGravitation extends TileBaseElectricBlock implements IInv
         final float maxExtract = (float) (numBlocks * strength);
         this.storage.setMaxExtract(maxExtract);
     }
+
+    @Override
+    public boolean isUseableByPlayer(EntityPlayer entityplayer) {
+        return super.isUseableByPlayer(entityplayer);
+    }
 }


### PR DESCRIPTION
Interesting java quirk where the compiler sees `isUseableByPlayer` from the super class (which does not implement `IInventory`) and is ok with it. But during runtime the JVM doesn't know that `isUseableByPlayer` is implemented in a base class and throws `AbstractMethodError`

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20153