### PR TITLE
Fix mothership travel time when light speed is reached

### DIFF
--- a/src/main/java/de/katzenpapst/amunra/helper/AstronomyHelper.java
+++ b/src/main/java/de/katzenpapst/amunra/helper/AstronomyHelper.java
@@ -488,7 +488,7 @@ public class AstronomyHelper {
 
         if (time > tEnd) {
             // how far did we come in tEnd
-            final double halfDistanceReached = 0.5D * accel * tEnd;
+            final double halfDistanceReached = 0.5D * maxSpeed * tEnd;
             final double halfDistanceRemaining = halfDistance - halfDistanceReached;
             // now, how long will it take us for the rest at contant speed?
             // x = v*t => t = x/v


### PR DESCRIPTION
The previous calculation was completely incorrect and basically completely discarded the distance already traveled.
This resulted in longer travel times when light speed was reached during travel.

For example, trying to travel from the overworld to RA would previously take ~1350 seconds with 1 ion thruster base and ~1406 seconds with 2 ion thruster bases. Now it'll take ~1350 and ~956 seconds respectively (ignoring that you can't actually start this specific trip due to insufficient fuel, but the concept is the same for any other combination).